### PR TITLE
Update Docker Compose to support Apple M1 Chip

### DIFF
--- a/deployment/docker-compose-local-basic.yml
+++ b/deployment/docker-compose-local-basic.yml
@@ -17,6 +17,7 @@ services:
 
   result-frontend:
     image: dna-frontend
+    platform: linux/amd64
     build:
       context: ../packages/frontend/
       dockerfile: ../../deployment/dockerfiles/app/result-frontend.Dockerfile
@@ -44,6 +45,7 @@ services:
 
   result-backend:
     image: dna-backend
+    platform: linux/amd64
     build:
       context: ../packages/backend/
       dockerfile: ../../deployment/dockerfiles/app/result-backend.Dockerfile
@@ -63,6 +65,7 @@ services:
 
   db:
     image: postgres:10
+    platform: linux/amd64
     restart: on-failure
     environment:
       - "POSTGRES_USER=admin"


### PR DESCRIPTION
Current beta version of docker requires you to specify a --platform=linux/amd64 each time you need to build or run an amd64 image/container.

The documentation mentions

When running an image with multi-architecture support, docker will automatically select an image variant which matches your OS and architecture.